### PR TITLE
Add multi-configuration capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ module MyApp
       TestIds.configure do |config|
         config.bins.include << (100..500)
         config.softbins = :bbb000
-        config.testnumbers do |bin, softbin|
+        config.numbers do |bin, softbin|
           (softbin * 10) + bin 
         end
       end

--- a/lib/test_ids.rb
+++ b/lib/test_ids.rb
@@ -19,7 +19,7 @@ module TestIds
   end
 
   class <<self
-    
+
     def store
       unless @configuration
         fail 'The test ID generator has to be configured before you can start using it'
@@ -78,8 +78,7 @@ module TestIds
         @configuration[_id] ||= Configuration.new(_id)
         set_current_configuration(_id)
       else
-        Origen.log.warn "Warning: You are attempting to configure an existing configuration: '#{_id}'"
-        Origen.log.warn "         Skipping re-configure, but setting '#{_id}' to current"
+        # Configuration already exists, skip re-configure, but set configuration to current
         set_current_configuration(_id)
         return      
       end
@@ -103,6 +102,10 @@ module TestIds
         fail "Configuration '#{_id}' does not exist"
       end
       @current_configuration = @configuration[_id]
+    end
+    
+    def empty?
+      @configuration.nil?
     end
     
     private

--- a/lib/test_ids.rb
+++ b/lib/test_ids.rb
@@ -19,42 +19,92 @@ module TestIds
   end
 
   class <<self
+    
     def store
       unless @configuration
         fail 'The test ID generator has to be configured before you can start using it'
       end
-      @store ||= Store.new
+
+      # Note: TestIds will keep a hash of stores
+      #
+      @store = {} if @store.nil?               # Empty has if this is first store object
+      
+      # Return existing or create new store object in store hash
+      @store[config_id] ||= Store.new(config_id)
     end
 
     def allocator
       unless @configuration
         fail 'The test ID generator has to be configured before you can start using it'
       end
-      @allocator ||= Allocator.new
+
+      # Note: TestIds will keep a hash of allocators
+      #
+      @allocator = {} if @allocator.nil?       # Empty has if this is first allocator object
+
+      # Return existing or create new store object in allocator hash
+      @allocator[config_id] ||= Allocator.new(config_id)     
     end
 
+    # Returns the id of the current configuration in-use, use this to access store and allocator
+    def config_id
+      current_configuration.id
+    end
+    
     def configuration
       if block_given?
         configure do |config|
           yield config
         end
       else
-        @configuration ||
+        @configuration[config_id] ||
           fail('You have to create the configuration first before you can access it')
       end
     end
     alias_method :config, :configuration
 
-    def configure
-      if @configuration
-        fail "You can't modify an existing test IDs configuration"
+    def configure(options = {})
+      # Don't force 'id' usage
+      _id = options[:id] || :not_specified
+
+      # Create empty hash if first configuration
+      @configuration = {} if @configuration.nil?
+
+      # Note: TestIds will keep a hash of configurations with the 'id' as the key
+      #
+      # If this configuration doesn't exist, create new configuration (hash item)
+      # Else, shoot user a warning and set configuration as current (but don't allow bin/tnum changes)
+      if @configuration[_id].nil?
+        @configuration[_id] ||= Configuration.new(_id)
+        set_current_configuration(_id)
+      else
+        Origen.log.warn "Warning: You are attempting to configure an existing configuration: '#{_id}'"
+        Origen.log.warn "         Skipping re-configure, but setting '#{_id}' to current"
+        set_current_configuration(_id)
+        return      
       end
-      @configuration = Configuration.new
-      yield @configuration
-      @configuration.validate!
+      yield @configuration[_id]
+      @configuration[_id].validate!
       allocator.prepare
     end
 
+    def current_configuration
+      unless @configuration
+        fail 'The test ID generator has to be configured before you can start using it'
+      end
+      @current_configuration
+    end
+
+    def set_current_configuration(_id)
+      unless @configuration
+        fail 'The test ID generator has to be configured before you can start using it'
+      end
+      if @configuration[_id].nil?
+        fail "Configuration '#{_id}' does not exist"
+      end
+      @current_configuration = @configuration[_id]
+    end
+    
     private
 
     # For testing, clears all instances including the configuration

--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -6,9 +6,11 @@ module TestIds
     def initialize
       @@allocators ||= 0
       @@allocators += 1
-      if @@allocators > 1 && !TestIds.send(:testing?)
-        fail 'TestIds::Allocators is a singleton, there can be only one'
-      end
+      
+      @id = TestIds.config.id
+      # if @@allocators > 1 && !TestIds.send(:testing?)
+      #   fail 'TestIds::Allocators is a singleton, there can be only one'
+      # end
     end
 
     # Main method to inject generated bin and test numbers, the given
@@ -122,7 +124,7 @@ module TestIds
     end
 
     def git
-      @git ||= Git.new(local: Pathname.new(file).dirname, remote: config.repo, no_pull: publish?)
+      @git ||= Git.new(local: Pathname.new(file).dirname, remote: config.repo, no_pull: publish?, id: id)
     end
 
     def prepare
@@ -354,6 +356,10 @@ module TestIds
       options[:name] ||= options.delete(:tname) || options.delete(:testname) ||
                          options.delete(:test_name)
       options[:index] ||= options.delete(:ix)
+    end
+    
+    def id
+      @id
     end
   end
 end

--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -111,7 +111,7 @@ module TestIds
           if git?
             dir = "#{Origen.app.imports_directory}/test_ids/#{Pathname.new(config.repo).basename}"
             FileUtils.mkdir_p(dir)
-            "#{dir}/store.json"
+            "#{dir}/store#{file_id}.json"
           else
             config.repo
           end
@@ -130,6 +130,18 @@ module TestIds
       end
     end
 
+    def id
+      @id
+    end
+
+    def file_id
+      if id == :not_specified
+        ''
+      else
+        '_' + id.to_s.downcase
+      end
+    end
+    
     private
 
     def publish?

--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -4,13 +4,9 @@ module TestIds
     attr_reader :config
 
     def initialize
-      @@allocators ||= 0
-      @@allocators += 1
-      
+      # keep 'id' value local to the allocator for easy identification
+      #   (matches with the corresponding configuration)
       @id = TestIds.config.id
-      # if @@allocators > 1 && !TestIds.send(:testing?)
-      #   fail 'TestIds::Allocators is a singleton, there can be only one'
-      # end
     end
 
     # Main method to inject generated bin and test numbers, the given

--- a/lib/test_ids/configuration.rb
+++ b/lib/test_ids/configuration.rb
@@ -45,6 +45,14 @@ module TestIds
       @on_completion = val.to_sym
     end
 
+    def initialize(_id)
+      @id = _id
+    end
+
+    def id
+      @id
+    end
+    
     def bins
       @bins ||= Item.new
     end

--- a/lib/test_ids/origen_testers/flow.rb
+++ b/lib/test_ids/origen_testers/flow.rb
@@ -5,7 +5,7 @@ module OrigenTesters
     # test numbers
     alias_method :_orig_test, :test
     def test(instance, options = {})
-      unless TestIds.config.empty?
+      unless TestIds.empty?
         TestIds.allocator.allocate(instance, options)
       end
       _orig_test(instance, options)

--- a/spec/multi_config_spec.rb
+++ b/spec/multi_config_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+describe "The multi-configurator" do
+
+  before :each do
+    TestIds.send(:reset)
+    configs.each do |cfg|
+      FileUtils.rm(f(cfg)) if File.exist?(f(cfg))
+    end
+  end
+
+  def configs
+    [:p1,:p2,:f1]
+  end
+  
+  def f(config)
+    "#{Origen.root}/tmp/store_#{config}.json"
+  end
+
+  def a(name, options = {})
+    TestIds.allocator.allocate(name, options)
+    options
+  end
+
+  it "is alive" do
+    i = 0
+    configs.each do |cfg|
+      i += 1
+      TestIds.configure id: cfg do |config|
+        config.softbins = i
+        config.numbers = :sx0
+        config.repo = nil
+      end
+      a(:t1)[:number].should == i * 100
+      a(:t2)[:number].should == i * 100 + 10
+      a(:t3)[:number].should == i * 100 + 20
+    end
+  end
+
+  it "current_configuration can be updated" do
+    i = 0
+    configs.each do |cfg|
+      i += 1
+      TestIds.configure id: cfg do |config|
+        config.softbins = i
+        config.numbers = :sx0
+        config.repo = nil
+      end
+      a(:t1)[:number].should == i * 100
+    end
+  
+    a(:t2)[:number].should == 3 * 100 + 10
+    
+    TestIds.configure id: configs[0] do |config|
+      # do nothing
+    end
+
+    a(:t2)[:number].should == 1 * 100 + 10
+    
+    TestIds.set_current_configuration(configs[1])
+
+    a(:t2)[:number].should == 2 * 100 + 10
+    
+  end
+
+
+end


### PR DESCRIPTION
Add functionality to have multiple configurations allowing multiple parallel (independent) allocators.

Still working on documentation update to go with an official release, but wanted to get this under review.
