### PR TITLE
extract test name only uses the test_id to extract the name

### DIFF
--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -479,7 +479,7 @@ module TestIds
     end
 
     def extract_test_name(instance, options)
-      name = options[:test_id] || options[:name]
+      name = options[:test_id]
       unless name
         if instance.is_a?(String)
           name = instance


### PR DESCRIPTION
@ginty does this change look okay to you? 

If I am passing the test name in the options, I still want the ability to use the instance name to be stored in the database,  if it is available.