### PR TITLE
Various enhancements

### DIFF
--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -10,7 +10,7 @@ when "test_ids:rollback"
   end
   exit 0
 
-when "test_ids:clear"
+when "test_ids:clear", "test_ids:repair"
   require "test_ids/commands/#{@command.split(':').last}"
   exit 0
 
@@ -18,6 +18,7 @@ else
   @plugin_commands << <<-EOT
  test_ids:rollback  Rollback the TestIds store to the given commit ID
  test_ids:clear     Clear the assignment database for bins, softbins, numbers or all
+ test_ids:repair    Repair the given database, see -h for more
   EOT
 
 end

--- a/lib/test_ids.rb
+++ b/lib/test_ids.rb
@@ -30,10 +30,17 @@ module TestIds
       }
     end
 
-    # Load an existing allocator, which will be loaded with an empty configuration
+    # Load an existing allocator, which will be loaded with a configuration based on what has
+    # been serialized into the database if present, otherwise it will have an empty configuration.
+    # Returns nil if the given database can not be found.
     # @api internal
     def load_allocator(id = nil)
-      Configuration.new(id).allocator
+      f = TestIds.database_file(id)
+      if File.exist?(f)
+        a = Configuration.new(id).allocator
+        a.load_configuration_from_store
+        a
+      end
     end
 
     def current_configuration

--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -101,8 +101,10 @@ module TestIds
       bin['number'] ||= allocate_bin(size: bin_size)
       bin['size'] ||= bin_size
       # If the softbin is based on the test number, then need to calculate the
-      # test number first
-      if config.softbins.algorithm && config.softbins.algorithm.to_s =~ /n/
+      # test number first.
+      # Also do the number first if the softbin is a callback and the number is not.
+      if (config.softbins.algorithm && config.softbins.algorithm.to_s =~ /n/) ||
+         (config.softbins.callback && !config.numbers.function?)
         number['number'] ||= allocate_number(bin: bin['number'], size: number_size)
         number['size'] ||= number_size
         softbin['number'] ||= allocate_softbin(bin: bin['number'], number: number['number'], size: softbin_size)
@@ -307,7 +309,7 @@ module TestIds
           f.puts '//    // This is a record of any numbers which have been manually assigned.'
           f.puts "//    'manually_assigned' => { 'bins' => {}, 'softbins' => {}, 'numbers' => {} },"
           f.puts '//'
-          f.puts '//    // This list all assigned numbers in chronological order of when they were last referenced.'
+          f.puts '//    // This contains all assigned numbers with a timestamp of when they were last referenced.'
           f.puts '//    // When numbers need to be reclaimed, they will be taken from the bottom of this list, i.e.'
           f.puts '//    // the numbers which have not been used for the longest time, e.g. because the test they'
           f.puts '//    // were assigned to has since been removed.'
@@ -459,7 +461,7 @@ module TestIds
         end
         number.to_i
       elsif callback = config.softbins.callback
-        callback.call(bin)
+        callback.call(bin, num)
       else
         if store['pointers']['softbins'] == 'done'
           reclaim_softbin(options)

--- a/lib/test_ids/bin_array.rb
+++ b/lib/test_ids/bin_array.rb
@@ -115,6 +115,43 @@ module TestIds
       end
     end
 
+    # Yields all number to the given block, one at a time
+    def yield_all
+      p = @pointer
+      nx = @next
+      @pointer = nil
+      @next = nil
+      while n = self.next
+        yield n
+      end
+      @pointer = p
+      @next = nx
+      nil
+    end
+
+    def to_json(*a)
+      @store.to_json(*a)
+    end
+
+    # @api private
+    def load_from_serialized(o)
+      @store = []
+      o.each do |i|
+        if i.is_a?(Numeric) || i.is_a?(Range)
+          self.<<(i)
+        elsif i.is_a?(String)
+          # JSON does not serialize ranges well, take care of it here
+          if i =~ /^(\d+)\.\.(\d+)$/
+            self.<<((Regexp.last_match(1).to_i)..(Regexp.last_match(2).to_i))
+          else
+            fail "Unknown bin array object type (#{o.class}): #{o}"
+          end
+        else
+          fail "Unknown bin array object type (#{o.class}): #{o}"
+        end
+      end
+    end
+
     private
 
     def previous_pointer(i)

--- a/lib/test_ids/commands/repair.rb
+++ b/lib/test_ids/commands/repair.rb
@@ -1,0 +1,60 @@
+require 'optparse'
+
+options = {}
+
+# App options are options that the application can supply to extend this command
+app_options = @application_options || []
+opt_parser = OptionParser.new do |opts|
+  opts.banner = <<-EOT
+Performs maintenance on the given TestId database.
+
+Usage: origen test_ids:repair ID [options]
+
+  EOT
+  # opts.on('--bins', 'Clear the bin database') {  options[:bins] = true }
+  # opts.on('--softbins', 'Clear the softbin database') {  options[:softbins] = true }
+  # opts.on('--numbers', 'Clear the test number database') {  options[:numbers] = true }
+  opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
+  app_options.each do |app_option|
+    opts.on(*app_option) {}
+  end
+  opts.separator ''
+  opts.on('-h', '--help', 'Show this message') { puts opts; exit 0 }
+end
+
+opt_parser.parse! ARGV
+
+local = TestIds::Git.path_to_local
+git = TestIds::Git.new(local: local)
+TestIds.repo = git.repo.remote.url
+git.get_lock
+rollback_id = nil
+stat = 0
+begin
+  # Get the commit before the lock to give the user later
+  rollback_id = git.repo.object('HEAD^').sha[0, 11]
+  if ARGV.empty?
+    puts 'You must supply the ID of the configuration database that you wish to repair'
+    exit 1
+  end
+  ARGV.each do |id|
+    a = TestIds.load_allocator(id)
+    if a
+      a.repair(options)
+      a.save
+    else
+      Origen.log.error "A configuration database named #{id} was not found!"
+      stat = 1
+    end
+  end
+ensure
+  git.publish
+end
+if rollback_id
+  puts
+  puts 'TestIDs database repaired as requested, you can rollback this change by running:'
+  puts
+  puts "   origen test_ids:rollback #{rollback_id}"
+  puts
+end
+exit stat

--- a/lib/test_ids/configuration.rb
+++ b/lib/test_ids/configuration.rb
@@ -25,13 +25,55 @@ module TestIds
         !!algorithm || !!callback
       end
 
-      # def compliant?(number)
-      # end
+      def valid?(number)
+        if function?
+          fail 'valid? is not supported for algorithm or callback-based assignments'
+        end
+        number = number.to_i
+        include.include?(number) && !exclude.include?(number)
+      end
 
       def freeze
         @include.freeze
         @exclude.freeze
         super
+      end
+
+      # @api private
+      def load_from_serialized(o)
+        if o.is_a?(Hash)
+          @size = o['size']
+          @include.load_from_serialized(o['include'])
+          @exclude.load_from_serialized(o['exclude'])
+        elsif o == 'callback'
+          callback do
+            fail 'The callback for this configuration is not available!'
+          end
+        else
+          self.algorithm = o
+        end
+      end
+
+      def to_json(*a)
+        if callback
+          'callback'.to_json(*a)
+        elsif algorithm
+          algorithm.to_s.to_json(*a)
+        else
+          {
+            'include' => include,
+            'exclude' => exclude,
+            'size'    => size
+          }.to_json(*a)
+        end
+      end
+
+      # Yields all included numbers to the given block, one at a time
+      def yield_all
+        include.yield_all do |i|
+          yield i unless exclude.include?(i)
+        end
+        nil
       end
     end
 
@@ -102,6 +144,21 @@ module TestIds
       softbins.freeze
       numbers.freeze
       super
+    end
+
+    def to_json(*a)
+      {
+        'bins'     => bins,
+        'softbins' => softbins,
+        'numbers'  => numbers
+      }.to_json(*a)
+    end
+
+    # @api private
+    def load_from_serialized(store)
+      bins.load_from_serialized(store['bins'])
+      softbins.load_from_serialized(store['softbins'])
+      numbers.load_from_serialized(store['numbers'])
     end
   end
 end

--- a/lib/test_ids/configuration.rb
+++ b/lib/test_ids/configuration.rb
@@ -92,7 +92,7 @@ module TestIds
       @bins ||= Item.new
     end
 
-    def softbins
+    def softbins(&block)
       @softbins ||= Item.new
       if block_given?
         @softbins.callback(&block)

--- a/spec/bin_array_spec.rb
+++ b/spec/bin_array_spec.rb
@@ -67,4 +67,25 @@ describe "A Bin Array" do
     b.include?(30).should == true
     b.include?(31).should == false
   end
+
+  it "can yield all numbers in the range" do
+    b = TestIds::BinArray.new
+    b << 10
+    b << (15..20)
+    b << 30
+
+    b.next.should == 10
+    b.next.should == 15
+
+    a = [10, 15, 16, 17, 18, 19, 20, 30]
+
+    b.yield_all do |i|
+      r = a.delete(i)
+      r.should_not == nil
+    end
+
+    a.empty?.should == true
+
+    b.next.should == 16
+  end
 end


### PR DESCRIPTION
This PR adds the following:

* If the softbin is defined as a callback and the test number is not, then the test number will now be generated first to make it available to the softbin callback

* Improved database (json) structure, including a header at the top of the file now to define the structure. It will automatically update existing databases to the new structure

* Added a repair command which does the following to the database:
  * Make all numbers defined in a range available if the allocation has moved onto the reclamation phase - could be an issue if more allocation has been added after the original was exhausted
  * Check that all existing assignments are valid per the current config, if not they will be removed and the tests will be reallocated next time the program generation is run
  * Check that all references (records of the last time a number was used) are valid for the current configuration, if not remove them