### PR TITLE
added in optional send_to_ate config

### DIFF
--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -121,15 +121,15 @@ module TestIds
       end
 
       # Update the supplied options hash that will be forwarded to the program generator
-      unless options.delete(:bin) == :none
+      unless options.delete(:bin) == :none || config.send_to_ate == false
         options[:bin] = bin['number']
         options[:bin_size] = bin['size']
       end
-      unless options.delete(:softbin) == :none
+      unless options.delete(:softbin) == :none || config.send_to_ate == false
         options[:softbin] = softbin['number']
         options[:softbin_size] = softbin['size']
       end
-      unless options.delete(:number) == :none
+      unless options.delete(:number) == :none || config.send_to_ate == false
         options[:number] = number['number']
         options[:number_size] = number['size']
       end

--- a/lib/test_ids/configuration.rb
+++ b/lib/test_ids/configuration.rb
@@ -76,6 +76,14 @@ module TestIds
       numbers.algorithm = val
     end
 
+    def send_to_ate=(val)
+      @send_to_ate = val
+    end
+
+    def send_to_ate
+      @send_to_ate
+    end
+
     def validate!
       unless validated?
         if bins.algorithm


### PR DESCRIPTION
Allows users to use all features of test_ids gem except actually inserting the bins/test numbers into the ATE flow file.

~~~ruby
     TestIds.repo =  'ssh://git@stash.company.com:7999/osdk/test_ids.git'  
      TestIds.configure do |config|
        config.bins.include << 5
        config.softbins = :bxxx
        config.send_to_ate = false
      end
~~~

If the user doesn't specify the 'send_to_ate' config option, the default behavior is used.

~~~shell
mybox $ origen specs

The bin allocator
  is alive
  bin numbers increment
  duplicate tests pick up the same bin number
  caller can override bin number
  manually assigned bins are reserved
  bin assignments can be inhibited by passing :none
  excluded bins are not used
  the system can be saved to a file and resumed
  previously assigned manual bins are reclaimed next time
  when all bins are used they will be re-used oldest first
  tests can reserve multiple bins

A Bin Array
  min and max works
  the next method works
  the next method can handle size reservations
  the include? method works

The multi-configurator
  is alive
  current_configuration can be updated

The number allocator
  is alive
  number numbers increment
  duplicate tests pick up the same number number
  caller can override number number
  number assignments can be inhibited by passing :none
  manually assigned numbers are reserved
  excluded numbers are not used
  the system can be saved to a file and resumed
  previously assigned manual numbers are reclaimed next time
  when all numbers are used they will be re-used oldest first
  the numbers can be generated from an algorithm
  algorithm based numbers can include an increment counter
  the numbers can be generated from a callback
  tests can reserve multiple numbers

The softbin allocator
  is alive
  softbin numbers increment
  duplicate tests pick up the same softbin number
  caller can override softbin number
  softbin assignments can be inhibited by passing :none
  manually assigned softbins are reserved
  excluded softbins are not used
  the system can be saved to a file and resumed
  previously assigned manual softbins are reclaimed next time
  when all softbins are used they will be re-used oldest first
  the softbins can be generated from an algorithm
  the softbin can be set to the test number
  algorithm based softbins can include an increment counter
  the softbins can be generated from a callback
  tests can reserve multiple softbins

Finished in 0.04767 seconds (files took 1.49 seconds to load)
46 examples, 0 failures
[SUCCESS]    0.020[0.020]    || 
[SUCCESS]    0.021[0.000]    ||     PPPPP      AA        SSSS    SSSS
[SUCCESS]    0.021[0.000]    ||     PP  PP    AAAA      SS  SS  SS  SS
[SUCCESS]    0.021[0.000]    ||     PPPPP    AA  AA      SS      SS
[SUCCESS]    0.021[0.000]    ||     PP      AAAAAAAA       SS      SS
[SUCCESS]    0.021[0.000]    ||     PP     AA      AA   SS  SS  SS  SS
[SUCCESS]    0.021[0.000]    ||     PP    AA        AA   SSSS    SSSS
[SUCCESS]    0.021[0.000]    || 
~~~