### PR TITLE
SMT8 Compatibility patch

### DIFF
--- a/lib/test_ids.rb
+++ b/lib/test_ids.rb
@@ -71,7 +71,8 @@ module TestIds
     # @api private
     def inject_flow_id(options)
       if Origen.interface_loaded?
-        options[:test_ids_flow_id] = Origen.interface.flow.id
+        flow = Origen.interface.flow
+        options[:test_ids_flow_id] = flow.try(:top_level).try(:id) || flow.id
       end
     end
 

--- a/lib/test_ids/origen_testers/flow.rb
+++ b/lib/test_ids/origen_testers/flow.rb
@@ -9,7 +9,7 @@ module OrigenTesters
     def test(instance, options = {})
       if TestIds.configured?
         unless options[:test_ids] == :notrack
-          options[:test_ids_flow_id] = id
+          options[:test_ids_flow_id] = try(:top_level).try(:id) || id
 
           TestIds.current_configuration.allocator.allocate(instance, options)
 


### PR DESCRIPTION
This is a small patch to the make the unique_by_flow feature work with the SMT8 program generator.

