### PR TITLE
bugfix for softbin ranges and updating the json database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.4.0
-  - 2.5.1
-# Needs work to enable 2.5.0 compatibility
-#  - 2.5.0
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
+
+before_install:
+  - gem install origen
 script:
-  - bundle exec origen -v
-  - bundle exec origen m debug
-  - bundle exec origen test -c
-  - bundle exec origen web compile --no-serve
-  - bundle exec origen lint --no-correct
+  - origen -v
+  - origen m debug
+  - origen test -c
+  - origen web compile --no-serve
+  - origen lint --no-correct
 env:
   - ORIGEN_GEM_USE_FROM_SYSTEM=false ORIGEN_GEM_MANAGE_BUNDLER=false

--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -56,9 +56,6 @@ module TestIds
         if previous_assigned_value == range.to_a[@pointer]
           @pointer += options[:size]
           assigned_value = range.to_a[@pointer]
-          # Since the assigned value for this test has now changed, update store to contain the newly assigned value
-          # so that when the json file is written, it contains the latest assigned value name.
-          store['pointers']['ranges'] = rangehash
         else
           # Because of the pointer calculations above, I don't think it will ever reach here, has not in my test cases so far!
           assigned_value = range.to_a[@pointer]
@@ -76,6 +73,8 @@ module TestIds
         Origen.log.error 'Assigned value not in range'
         fail
       end
+      # Since the assigned value for this test has now changed, update store to contain the newly assigned value
+      # so that when the json file is written, it contains the latest assigned value name.
       store['pointers']['ranges'] = rangehash
       assigned_value
     end

--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -65,6 +65,9 @@ module TestIds
         if previous_assigned_value == range.to_a[@pointer]
           @pointer += options[:size]
           assigned_value = range.to_a[@pointer]
+          # Since the assigned value for this test has now changed, update store to contain the newly assigned value
+          # so that when the json file is written, it contains the latest assigned value name.
+          store['pointers']['ranges'] = rangehash
         else
           # Because of the pointer calculations above, I don't think it will ever reach here, has not in my test cases so far!
           assigned_value = range.to_a[@pointer]


### PR DESCRIPTION
found a corner case.

In the current implementation, when the json file exists, the latest assigned softbin number from a range is read in using the pointers stored in the json file.

Observation was that the newly added test would correctly get the new softbin number assigned (as expected) but the pointer for the ranges in the json file did not correctly reflect the newly assigned number. This should fix that.