### PR TITLE
test_ids clear ranges option

### DIFF
--- a/config/shared_commands.rb
+++ b/config/shared_commands.rb
@@ -17,7 +17,7 @@ when "test_ids:clear", "test_ids:repair"
 else
   @plugin_commands << <<-EOT
  test_ids:rollback  Rollback the TestIds store to the given commit ID
- test_ids:clear     Clear the assignment database for bins, softbins, numbers or all
+ test_ids:clear     Clear the assignment database for bins, softbins, numbers, ranges or all for the given configuration database ID
  test_ids:repair    Repair the given database, see -h for more
   EOT
 

--- a/lib/test_ids/allocator.rb
+++ b/lib/test_ids/allocator.rb
@@ -296,7 +296,7 @@ module TestIds
       end
     end
 
-    # Clear the :bins, :softbins and/or :numbers by setting the options for each item to true
+    # Clear the :bins, :softbins and/or :numbers and/or :ranges by setting the options for each item
     def clear(options)
       if options[:softbin] || options[:softbins]
         store['assigned']['softbins'] = {}
@@ -315,6 +315,9 @@ module TestIds
         store['manually_assigned']['numbers'] = {}
         store['pointers']['numbers'] = nil
         store['references']['numbers'] = {}
+      end
+      if options[:range] || options[:ranges]
+        store['pointers']['ranges'] = nil
       end
     end
 

--- a/lib/test_ids/commands/clear.rb
+++ b/lib/test_ids/commands/clear.rb
@@ -18,6 +18,7 @@ Examples: origen test_ids:clear --bins                      # Clear the bins in 
   opts.on('--bins', 'Clear the bin database') {  options[:bins] = true }
   opts.on('--softbins', 'Clear the softbin database') {  options[:softbins] = true }
   opts.on('--numbers', 'Clear the test number database') {  options[:numbers] = true }
+  opts.on('--ranges', 'Clear the ranges database') {  options[:ranges] = true }
   # opts.on('-pl', '--plugin PLUGIN_NAME', String, 'Set current plugin') { |pl_n|  options[:current_plugin] = pl_n }
   opts.on('-d', '--debugger', 'Enable the debugger') {  options[:debugger] = true }
   app_options.each do |app_option|
@@ -38,6 +39,11 @@ begin
   # Get the commit before the lock to give the user later
   rollback_id = git.repo.object('HEAD^').sha[0, 11]
   a = TestIds.load_allocator(ARGV.first)
+  if a.nil?
+    Origen.log.error "No configuration file could be found for file ID: '#{ARGV.first}'!"
+    Origen.log.warn 'By default, the correct ID to pass in will need to match the filename in the form: store_<file id>.json'
+    fail
+  end
   a.clear(options)
   a.save
 ensure


### PR DESCRIPTION
While trying to clear the bins/softbins from a configuration database, the next run of the flow had skipped a bunch of softbins.

Looking at the json that was checked into the test ids database repo, it looks like the clear command had correctly clear bins/softbins, but had not cleared the range counter:

```json
  "pointers": {
    "bins": null,
    "softbins": null,
    "numbers": null,
    "ranges": {
        "12001..12199": "12019"
    }
```
I didn't see a way to clear this through the clear command, hence this PR;
Now when I run test_ids:clear with --ranges option with this PR, the output in the store is:
```json
  "pointers": {
    "bins": null,
    "softbins": null,
    "numbers": null,
    "ranges":  null
```
-----
Additionally, added an error message to provide more context on top of just: 
```bash
undefined method `clear' for nil:NilClass`
```